### PR TITLE
Exception handlers

### DIFF
--- a/src/Cache/CouchbaseStore.php
+++ b/src/Cache/CouchbaseStore.php
@@ -125,8 +125,12 @@ class CouchbaseStore extends TaggableStore implements Store
      */
     public function forget($key)
     {
-        $this->resolveKey($key);
-        $this->bucket->remove($this->resolveKey($key));
+        try {
+            $this->resolveKey($key);
+            $this->bucket->remove($this->resolveKey($key));
+        } catch (\Exception $e) {
+            // Ignore exceptions from remove
+        }
     }
 
     /**

--- a/src/Cache/LegacyCouchbaseStore.php
+++ b/src/Cache/LegacyCouchbaseStore.php
@@ -116,7 +116,11 @@ class LegacyCouchbaseStore extends TaggableStore implements Store
      */
     public function forever($key, $value)
     {
-        $this->bucket->insert($this->resolveKey($key), $value);
+        try {
+            $this->bucket->insert($this->resolveKey($key), $value);
+        } catch (CouchbaseException $e) {
+            // bucket->insert when called from resetTag in TagSet can throw CAS exceptions, ignore.
+        }
     }
 
     /**

--- a/src/Cache/LegacyCouchbaseStore.php
+++ b/src/Cache/LegacyCouchbaseStore.php
@@ -124,8 +124,12 @@ class LegacyCouchbaseStore extends TaggableStore implements Store
      */
     public function forget($key)
     {
-        $this->resolveKey($key);
-        $this->bucket->remove($this->resolveKey($key));
+        try {
+            $this->resolveKey($key);
+            $this->bucket->remove($this->resolveKey($key));
+        } catch (\Exception $e) {
+            // Ignore exceptions from remove
+        }
     }
 
     /**


### PR DESCRIPTION
Add exception handlers in forever() and forget() in LegacyCouchbaseStore. Otherwise forgetting a key that does not exist can throw an exception.
